### PR TITLE
[No JIRA Ticket] Isolate los_cache in engine.py, compute it only once

### DIFF
--- a/python/comprunner.py
+++ b/python/comprunner.py
@@ -61,7 +61,7 @@ def runais(world_state,players,player_discovery,tick,sname):
 def write_state_for_tick(world_state,players,player_discovery,i,tick,session):
     with open(masked_filename(session,i), 'wb') as outfile:
         d = {}
-        add_to_discovered(world_state,player_discovery[i],i, los_cache())
+        add_to_discovered(world_state,player_discovery[i],i)
         masked = mask_with_discovered(jsoncopy(world_state),player_discovery[i])
         d["world_state"] = masked
         d["players"] = strip_team_info(jsoncopy(players),i)

--- a/python/debugrunner.py
+++ b/python/debugrunner.py
@@ -44,14 +44,13 @@ FOW4 = "-f3" in sys.argv
 def play():
     world_state, players, generatedIDs, player_discovery = new_game(PLAYERS, SEED, shuffle)
     FOW_to_render = [FOW1,FOW2,FOW3,FOW4]
-    lc = los_cache()
     tick = 0
     while(True):
         collated_orders = []
 
         for i in range(4):
             if(PLAYERS[i] is not None):
-                add_to_discovered(world_state,player_discovery[i],i,lc)
+                add_to_discovered(world_state,player_discovery[i],i)
                 masked = mask_with_discovered(jsoncopy(world_state),player_discovery[i])
                 for c in PLAYERS[i].run(masked,strip_team_info(jsoncopy(players),i),i):
                     c["team"] = i

--- a/python/engine.py
+++ b/python/engine.py
@@ -91,6 +91,8 @@ ID_MAX = 2 ** 30
 # map size
 MAP_SIZE = 96
 
+LOS_CACHE = [[dx, dy] for dx in range(-LINE_OF_SIGHT,1+LINE_OF_SIGHT) for dy in range(-LINE_OF_SIGHT,1+LINE_OF_SIGHT) if abs(dx) + abs(dy) <= LINE_OF_SIGHT]
+
 def generate_ID(generated):
     val = random.randint(0,ID_MAX)
     while(val in generated):
@@ -467,19 +469,11 @@ def emap_from_worldstate(world_state):
                 emap[world_state[x][y]["id"]] = ([x,y], world_state[x][y])
     return emap
 
-def los_cache():
-    out = []
-    for dx in range(-LINE_OF_SIGHT,1+LINE_OF_SIGHT):
-        for dy in range(-LINE_OF_SIGHT,1+LINE_OF_SIGHT):  
-            if((abs(dx) + abs(dy)) <= LINE_OF_SIGHT):
-                out.append([dx,dy])
-    return out
-
-def add_to_discovered(world_state,discovered,player_idx, lc):
+def add_to_discovered(world_state,discovered,player_idx):
     for x in range(MAP_SIZE):
         for y in range(MAP_SIZE):
                 if(world_state[x][y] is not None and world_state[x][y]["team"] == player_idx):
-                    for d in lc:
+                    for d in LOS_CACHE:
                         if((x+d[0]) >= 0 and (y+d[1]) >= 0 and (x+d[0]) < MAP_SIZE and (y+d[1]) < MAP_SIZE):
                             idx = ((d[1]+y) * MAP_SIZE) + (d[0]+x)
                             discovered.add(idx)


### PR DESCRIPTION
comprunner.py will recompute los_cache 4 times per tick. It's possible to only build los_cache once in comprunner.py, but since I'm doing it there I figured it would be best to reorg things and put los_cache entirely within engine.py, so runners don't need to touch it.